### PR TITLE
Update README.md with Docker instructions and Keycloak admin console URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ npm run dev
 
 # Docker instructions
 
+To run the project using Docker, you will need to have Docker installed on your machine.
+
 To enable the Keycloak authentication, first install Keycloak-connect by running the following command:
 ```
 npm install keycloak-connect
@@ -100,6 +102,8 @@ Then, you need to run the following command to start the Docker container:
 ```
 docker-compose -f config/docker/keycloak.yml up
 ```
+
+The admin console for Keycloak can be accessed at http://localhost:9080
 
 
 


### PR DESCRIPTION
This pull request includes updates to the Docker instructions in the `README.md` file to provide additional clarity on running the project using Docker and accessing the Keycloak admin console.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R90-R91): Added a note to ensure Docker is installed on the machine before running the project.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R106-R107): Included information on accessing the Keycloak admin console at `http://localhost:9080`.